### PR TITLE
add ICPianoKeyboardElement class

### DIFF
--- a/CoypuIDE/ICPianoBlackNoteElement.class.st
+++ b/CoypuIDE/ICPianoBlackNoteElement.class.st
@@ -4,6 +4,10 @@ I am a Black Key of the Piano Keyboard
 Class {
 	#name : 'ICPianoBlackNoteElement',
 	#superclass : 'ToElement',
+	#instVars : [
+		'width',
+		'height'
+	],
 	#category : 'CoypuIDE-PianoKeyboard',
 	#package : 'CoypuIDE',
 	#tag : 'PianoKeyboard'
@@ -17,11 +21,30 @@ ICPianoBlackNoteElement class >> newWithColor: aColor [
 		  yourself
 ]
 
+{ #category : 'api - bounds' }
+ICPianoBlackNoteElement >> height: anInteger [
+
+	height := anInteger 
+]
+
 { #category : 'initialization' }
 ICPianoBlackNoteElement >> initialize [
 
 	super initialize.
-	self size: 16 @ 70.
+	width := 16.
+	height := 70.
+	self size: width @ height.
 	self geometry: BlRectangleGeometry new.
 	self constraintsDo: [ :e | e frame vertical alignTop ]
+]
+
+{ #category : 'api - bounds' }
+ICPianoBlackNoteElement >> width [ 
+^ width
+]
+
+{ #category : 'api - bounds' }
+ICPianoBlackNoteElement >> width: anInteger [
+
+	width := anInteger 
 ]

--- a/CoypuIDE/ICPianoKeyboard.class.st
+++ b/CoypuIDE/ICPianoKeyboard.class.st
@@ -10,7 +10,7 @@ Class {
 	#instVars : [
 		'whiteKeyColor',
 		'blackKeyColor',
-		'whiteNoteNames',
+		'whiteNotesArray',
 		'startNote',
 		'whitenotes',
 		'nOctaves',
@@ -53,13 +53,13 @@ ICPianoKeyboard >> blacknotes [
 ICPianoKeyboard >> initialize [
 
 	super initialize.
-	whiteNoteNames := #( 'C' 'D' 'E' 'F' 'G' 'A' 'B' ).
+   whiteNotesArray := OrderedCollection new.
 	self border: (BlBorder paint: Color black width: 2).
 	self geometry: BlRectangleGeometry new.
 	whiteKeyColor := Color gray: 0.95.
 	blackKeyColor := Color black.
 	self
-		nOctaves: 5;
+		nOctaves: 4;
 		startNote: 'C'
 ]
 
@@ -145,15 +145,14 @@ ICPianoKeyboard >> initializeWhiteHandlers [
 { #category : 'initialization' }
 ICPianoKeyboard >> initializeWhiteNotes [
 
-	| wN wx bx whiteNoteDescriptions  |
+	| wN wx bx whiteNoteDescriptions |
 	"initializing notes for the two octaves"
-	
 	whitenotes := OrderedCollection new.
-	blacknotes := OrderedCollection new.
+
 	"for now the note description is not used and only for the white notes"
 	whiteNoteDescriptions := OrderedCollection new.
 	nOctaves timesRepeat: [
-		self whiteNoteNames do: [ :e | whiteNoteDescriptions add: e ] ].
+		7 timesRepeat: [ :e | whiteNoteDescriptions add: e ] ].
 	wx := 0.
 	bx := 0.
 	"adding the white notes"
@@ -229,12 +228,6 @@ ICPianoKeyboard >> startNote: aNote [
 { #category : 'accessing' }
 ICPianoKeyboard >> whiteKeyColor [
 	^ whiteKeyColor
-]
-
-{ #category : 'accessing' }
-ICPianoKeyboard >> whiteNoteNames [
-
-^ whiteNoteNames 
 ]
 
 { #category : 'accessing' }

--- a/CoypuIDE/ICPianoKeyboardElement.class.st
+++ b/CoypuIDE/ICPianoKeyboardElement.class.st
@@ -1,0 +1,10 @@
+"
+I am a PianoKeyboard that can be used with Coypu and Phausto
+"
+Class {
+	#name : 'ICPianoKeyboardElement',
+	#superclass : 'ToElement',
+	#category : 'CoypuIDE-PianoKeyboard',
+	#package : 'CoypuIDE',
+	#tag : 'PianoKeyboard'
+}

--- a/CoypuIDE/ICPianoWhiteNoteElement.class.st
+++ b/CoypuIDE/ICPianoWhiteNoteElement.class.st
@@ -4,6 +4,10 @@ I am a White Key of the PianoKeyboard
 Class {
 	#name : 'ICPianoWhiteNoteElement',
 	#superclass : 'ToElement',
+	#instVars : [
+		'width',
+		'height'
+	],
 	#classVars : [
 		'note'
 	],
@@ -18,11 +22,25 @@ ICPianoWhiteNoteElement class >> newWithColor: aColor [
 	^ self new background: aColor; yourself
 ]
 
+{ #category : 'api - bounds' }
+ICPianoWhiteNoteElement >> height [
+
+^ height
+]
+
+{ #category : 'api - bounds' }
+ICPianoWhiteNoteElement >> height: anInteger [
+
+	height := anInteger 
+]
+
 { #category : 'initialization' }
 ICPianoWhiteNoteElement >> initialize [
 
 	super initialize.
-	self size: 32 @ 120.
+	width := 32.
+	height := 120. 
+	self size: width @ height.
 	self geometry: BlRectangleGeometry new.
 	self border: (BlBorder paint: Color black width: 1)
 ]
@@ -36,4 +54,16 @@ ICPianoWhiteNoteElement >> note [
 ICPianoWhiteNoteElement >> note: aNote [
 
 note:= aNote .
+]
+
+{ #category : 'api - bounds' }
+ICPianoWhiteNoteElement >> width [
+
+	 ^ width 
+]
+
+{ #category : 'api - bounds' }
+ICPianoWhiteNoteElement >> width: anInteger [
+
+	width := anInteger
 ]


### PR DESCRIPTION
the PianoKeyboard implemented by Alexis (still in the MoofLod package) - was looking good but actually was useless to control an instrument. I am starting a new PianoKeyboard from scratch taking the Juce KeyboardComponent as a model. 
This means that we need a single Toplo widget where depending on the click position a note is sent.